### PR TITLE
Se agregó MapStruct para utilizar DTOs. Se utiliza para mapear objetos.

### DIFF
--- a/ejb/pom.xml
+++ b/ejb/pom.xml
@@ -39,6 +39,10 @@
         </license>
     </licenses>
 
+    <properties>
+        <org.mapstruct.version>1.0.0.Final</org.mapstruct.version>
+    </properties>
+
     <dependencies>
 
         <!-- Declare the APIs we depend on and need for compilation. All of 
@@ -156,6 +160,12 @@
             <artifactId>lombok</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${org.mapstruct.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -185,6 +195,36 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.bsc.maven</groupId>
+                <artifactId>maven-processor-plugin</artifactId>
+                <version>2.2.3</version>
+                <configuration>
+                    <defaultOutputDirectory>
+                        ${project.build.directory}/generated-sources
+                    </defaultOutputDirectory>
+                    <processors>
+                        <processor>org.mapstruct.ap.MappingProcessor</processor>
+                    </processors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>process</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>process</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.mapstruct</groupId>
+                        <artifactId>mapstruct-processor</artifactId>
+                        <version>${org.mapstruct.version}</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/ejb/src/main/java/com/utn/tesis/mapping/dto/MateriaDTO.java
+++ b/ejb/src/main/java/com/utn/tesis/mapping/dto/MateriaDTO.java
@@ -1,0 +1,62 @@
+package com.utn.tesis.mapping.dto;
+
+import java.util.Calendar;
+
+public class MateriaDTO {
+
+    private Long id;
+    private String nombre;
+    private String nivel;
+    private String descripcion;
+    private String motivoBaja;
+    private Calendar fechaBaja;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNombre() {
+        return nombre;
+    }
+
+    public void setNombre(String nombre) {
+        this.nombre = nombre;
+    }
+
+    public String getNivel() {
+        return nivel;
+    }
+
+    public void setNivel(String nivel) {
+        this.nivel = nivel;
+    }
+
+    public String getDescripcion() {
+        return descripcion;
+    }
+
+    public void setDescripcion(String descripcion) {
+        this.descripcion = descripcion;
+    }
+
+    public String getMotivoBaja() {
+        return motivoBaja;
+    }
+
+    public void setMotivoBaja(String motivoBaja) {
+        this.motivoBaja = motivoBaja;
+    }
+
+    public Calendar getFechaBaja() {
+        return fechaBaja;
+    }
+
+    public void setFechaBaja(Calendar fechaBaja) {
+        this.fechaBaja = fechaBaja;
+    }
+}
+

--- a/ejb/src/main/java/com/utn/tesis/mapping/mapper/MateriaMapper.java
+++ b/ejb/src/main/java/com/utn/tesis/mapping/mapper/MateriaMapper.java
@@ -1,0 +1,27 @@
+package com.utn.tesis.mapping.mapper;
+
+
+import com.utn.tesis.mapping.dto.MateriaDTO;
+import com.utn.tesis.model.Materia;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: Enzo
+ * Date: 20/01/16
+ * Time: 20:19
+ */
+@Mapper(componentModel = "cdi")
+public interface MateriaMapper {
+
+    MateriaMapper INSTANCE = Mappers.getMapper(MateriaMapper.class);
+
+    //    @Mapping(target = "nivel", expression = "java(materia.getNivel().toString())")
+    MateriaDTO toDTO(Materia materia);
+
+    Materia fromDTO(MateriaDTO materiaDTO);
+
+    void updateFromDTO(MateriaDTO materiaDTO, @MappingTarget Materia materia);
+}

--- a/web/src/main/java/com/utn/tesis/api/MateriaAPI.java
+++ b/web/src/main/java/com/utn/tesis/api/MateriaAPI.java
@@ -23,7 +23,6 @@ public class MateriaAPI extends BaseAPI<Materia> {
     @Inject
     private MateriaService materiaService;
 
-
     @Override
     public BaseService<Materia> getEjbInstance() {
         return materiaService;


### PR DESCRIPTION
Se agregó la dependencia de MapStruct en el proyecto ejb. Asimismo un plugin en el mismo pom que se encarga de generar los mappers correspondientes. 
Hay un ejemplo con hecho con materia. El mapper MateriaMapper tiene 3 metodos:
```java
MateriaMapper INSTANCE = Mappers.getMapper(MateriaMapper.class);

    MateriaDTO toDTO(Materia materia);
    Materia fromDTO(MateriaDTO materiaDTO);
    void updateFromDTO(MateriaDTO materiaDTO, @MappingTarget Materia materia);
```
toDTO genera un DTO a partir de la entity.
fromDTO genera una entity a partir del DTO.
updateFromDTO hace un update de la instancia pasada como segundo parámetro. Nos va a servir para impactar cambios sin modificar los datos que no le pasamos al DTO. 

Para utilizar el mapper: ``MateriaMapper.INSTANCE.toDTO(materia)``
O si le agregan ``componentModel = "cdi"`` 
```java
@Mapper(componentModel = "cdi")
public interface MateriaMapper
```
pueden injectarlo a traves de CDI
```java
@Inject
    private MateriaMapper materiaMapper;
```
Iria por la segunda opción.

Más información sobre como mapear y demás: http://mapstruct.org/news/page/2.html 

* No utilizar en conjunto a lombok. Se ve que lombok no llega a generar el código antes de que se ejecute el plugin de MapStruct, por lo que no encuentra ningun get y set y no genera los mapeos correspondientes.